### PR TITLE
Fix image_test.snap commit hash

### DIFF
--- a/internal/image/__snapshots__/image_test.snap
+++ b/internal/image/__snapshots__/image_test.snap
@@ -1240,7 +1240,7 @@
         {
           "name": "ca-certificates-cacert",
           "version": "20191127-r2",
-          "commit": "9677580919b73ca6eff94d3d31b9a846b4e40612",
+          "commit": "f24637bad53762e9a2f847dd2e67bb91b1a615c2",
           "ecosystem": "Alpine:v3.18",
           "compareAs": "Alpine"
         },

--- a/internal/image/fixtures/test-alpine.Dockerfile
+++ b/internal/image/fixtures/test-alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10sha256:451eee8bedcb2f029756dc3e9d73bab0e7943c1ac55cff3a4861c52a0fdd3e98
+FROM alpine:3.10@sha256:451eee8bedcb2f029756dc3e9d73bab0e7943c1ac55cff3a4861c52a0fdd3e98
 
 # Switch the version to 3.19 to show the advisories published for the latest alpine versions
 COPY "alpine-3.19-alpine-release" "/etc/alpine-release"

--- a/internal/image/fixtures/test-alpine.Dockerfile
+++ b/internal/image/fixtures/test-alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.10sha256:451eee8bedcb2f029756dc3e9d73bab0e7943c1ac55cff3a4861c52a0fdd3e98
 
 # Switch the version to 3.19 to show the advisories published for the latest alpine versions
 COPY "alpine-3.19-alpine-release" "/etc/alpine-release"


### PR DESCRIPTION
I was getting the following test failures:

```
$ ./scripts/run_tests.sh
skipped building internal/image/fixtures/test-alpine.tar (already exists)
skipped building internal/image/fixtures/test-node_modules-npm-empty.tar (already exists)
skipped building internal/image/fixtures/test-node_modules-npm-full.tar (already exists)
skipped building internal/image/fixtures/test-node_modules-pnpm-empty.tar (already exists)
skipped building internal/image/fixtures/test-node_modules-pnpm-full.tar (already exists)
skipped building internal/image/fixtures/test-node_modules-yarn-empty.tar (already exists)
skipped building internal/image/fixtures/test-node_modules-yarn-full.tar (already exists)
go: downloading github.com/google/go-containerregistry v0.19.1
...
...
ok      github.com/google/osv-scanner/internal/customgitignore  1.526s  coverage: 82.2% of statements in ./...
--- FAIL: TestScanImage (0.00s)
    --- FAIL: TestScanImage/Alpine_3.10_image_tar_with_3.18_version_file (0.17s)
        image_test.go:88:
            - Snapshot - 1
            + Received + 1

            @@ -35,7 +35,7 @@

                      {
                        "name": "ca-certificates-cacert",
                        "version": "20191127-r2",
            -           "commit": "9677580919b73ca6eff94d3d31b9a846b4e40612",
            +           "commit": "f24637bad53762e9a2f847dd2e67bb91b1a615c2",
                        "ecosystem": "Alpine:v3.18",
                        "compareAs": "Alpine"
                      },

            at ../__snapshots__/image_test.snap:1205

FAIL
coverage: 13.8% of statements in ./...
FAIL    github.com/google/osv-scanner/internal/image    4.042s
ok      github.com/google/osv-scanner/internal/local    1.858s  coverage: 4.0% of statements in ./...
...
ok      github.com/google/osv-scanner/pkg/spdx  1.355s  coverage: 100.0% of statements in ./...
FAIL
```

I've tried reseting the fixtures dir: with,

```
$ rm internal/image/fixtures/*
$ git checkout internal/image/fixtures/
```

... and then and restarting Docker Desktop (macos). But got the same result.
