### PR TITLE
ci: put `osv-scalibr` updates in their own group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,7 @@
     },
     {
       "matchPackageNames": ["osv-scalibr"],
+      "groupName": "osv-scalibr"
       "enabled": true
     }
   ],


### PR DESCRIPTION
I think this is needed because we are already grouping dependencies in the `golang` category into a group, so by having an explicit group name for this package rule it should cause them not to get merged